### PR TITLE
Add 1073mV option

### DIFF
--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -54,6 +54,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         // BM1370 voltage options
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1000));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1060));
+        cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1073));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1100));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1150));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1200));
@@ -73,6 +74,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(575));
 
         // BM1368 voltage options
+        cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1073));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1100));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1150));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1166));
@@ -93,6 +95,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(575));
 
         // BM1366 voltage options
+        cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1073));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1100));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1150));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1200));
@@ -113,6 +116,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(600));
 
         // BM1397 voltage options
+        cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1073));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1100));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1150));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1200));
@@ -129,6 +133,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(425));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(450));
 
+        cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1073));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1200));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1250));
         cJSON_AddItemToArray(voltageOptions, cJSON_CreateNumber(1300));

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -137,7 +137,7 @@ export class SystemService {
       return of({
         ASICModel: eASICModel.BM1366,
         frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 550, 575],
-        voltageOptions: [1100, 1150, 1200, 1250, 1300]
+        voltageOptions: [1073, 1100, 1150, 1200, 1250, 1300]
       }).pipe(delay(1000));
     }
   }

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -509,7 +509,7 @@ paths:
                     items:
                       type: number
                     examples:
-                      - [1100, 1150, 1200, 1250, 1300]
+                      - [1073, 1100, 1150, 1200, 1250, 1300]
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':

--- a/main/power/TPS546.c
+++ b/main/power/TPS546.c
@@ -310,6 +310,7 @@ static uint16_t float_2_ulinear16(float value)
 {
     uint8_t voutmode;
     float exponent;
+    float scaled;
     uint16_t result;
 
     smb_read_byte(PMBUS_VOUT_MODE, &voutmode);
@@ -320,7 +321,8 @@ static uint16_t float_2_ulinear16(float value)
         exponent = (voutmode & 0x1F);
     }
 
-    result = (value / powf(2.0, exponent));
+    scaled = value / powf(2.0, exponent);
+    result = (uint16_t)ceilf(scaled);
 
     return result;
 }


### PR DESCRIPTION
## Summary
- insert 1073 into ASIC voltage settings
- show 1073 mV voltage option in mock data and OpenAPI docs
- round up regulator value calculation

## Testing
- `npm test` *(fails: `ng` not found)*