### PR TITLE
Add 540 MHz frequency option

### DIFF
--- a/config-102.cvs
+++ b/config-102.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,425
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1400
 asicmodel,data,string,BM1397
 devicemodel,data,string,max

--- a/config-201.cvs
+++ b/config-201.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/config-202.cvs
+++ b/config-202.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/config-203.cvs
+++ b/config-203.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/config-204.cvs
+++ b/config-204.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/config-205.cvs
+++ b/config-205.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/config-401.cvs
+++ b/config-401.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,490
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1166
 asicmodel,data,string,BM1368
 devicemodel,data,string,supra

--- a/config-402.cvs
+++ b/config-402.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,490
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1166
 asicmodel,data,string,BM1368
 devicemodel,data,string,supra

--- a/config-403.cvs
+++ b/config-403.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,490
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1166
 asicmodel,data,string,BM1368
 devicemodel,data,string,supra

--- a/config-601.cvs
+++ b/config-601.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,525
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1150
 asicmodel,data,string,BM1370
 devicemodel,data,string,gamma

--- a/config-602.cvs
+++ b/config-602.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,525
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1150
 asicmodel,data,string,BM1370
 devicemodel,data,string,gamma

--- a/config-800x.cvs
+++ b/config-800x.cvs
@@ -11,7 +11,7 @@ fbstratumurl,data,string,solo.ckpool.org
 fbstratumport,data,u16,3333
 fbstratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 fbstratumpass,data,string,x
-asicfrequency,data,u16,525
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1150
 asicmodel,data,string,BM1370
 devicemodel,data,string,gammaturbo

--- a/config.cvs.example
+++ b/config.cvs.example
@@ -7,7 +7,7 @@ stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe
 stratumpass,data,string,x
-asicfrequency,data,u16,485
+asicfrequency,data,u16,540
 asicvoltage,data,u16,1200
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra

--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -47,6 +47,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(400));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(490));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(525));
+        cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(540));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(550));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(600));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(625));
@@ -69,6 +70,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(490));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(500));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(525));
+        cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(540));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(550));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(575));
 
@@ -89,6 +91,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(485));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(500));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(525));
+        cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(540));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(550));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(575));
 
@@ -108,6 +111,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(485));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(500));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(525));
+        cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(540));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(550));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(575));
         cJSON_AddItemToArray(freqOptions, cJSON_CreateNumber(600));

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -54,7 +54,7 @@ export class SystemService {
           stratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
           fallbackStratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
           isUsingFallbackStratum: true,
-          frequency: 485,
+          frequency: 540,
           version: "2.0",
           idfVersion: "v5.1.2",
           boardVersion: "204",
@@ -136,7 +136,7 @@ export class SystemService {
       // Mock data for development
       return of({
         ASICModel: eASICModel.BM1366,
-        frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 550, 575],
+        frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 540, 550, 575],
         voltageOptions: [1100, 1150, 1200, 1250, 1300]
       }).pipe(delay(1000));
     }

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -502,7 +502,7 @@ paths:
                     items:
                       type: number
                     examples:
-                      - [400, 425, 450, 475, 485, 500, 525, 550, 575]
+                      - [400, 425, 450, 475, 485, 500, 525, 540, 550, 575]
                   voltageOptions:
                     type: array
                     description: Available voltage options for the ASIC model in millivolts


### PR DESCRIPTION
## Summary
- add 540 MHz to ASIC frequency option arrays
- update UI mock data to include 540 MHz
- document updated frequency list in API schema
- set default config frequency to 540 MHz

## Testing
- `git status --short`